### PR TITLE
* [android] make native execution not throw in most case.

### DIFF
--- a/android/inspector/src/main/java/com/taobao/weex/devtools/debug/DebugBridge.java
+++ b/android/inspector/src/main/java/com/taobao/weex/devtools/debug/DebugBridge.java
@@ -148,7 +148,7 @@ public class DebugBridge implements IWXBridge {
         if (mJsManager != null) {
             return  mJsManager.callNative(instanceId, tasks, callback);
         }else{
-            return WXBridgeManager.INSTANCE_RENDERING_ERROR;
+            return IWXBridge.INSTANCE_RENDERING_ERROR;
         }
     }
 

--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKEngine.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKEngine.java
@@ -220,7 +220,7 @@ public class WXSDKEngine {
     WXEnvironment.sApplication = application;
     WXEnvironment.JsFrameworkInit = false;
 
-    WXBridgeManager.getInstance().getJSHandler().post(new Runnable() {
+    WXBridgeManager.getInstance().post(new Runnable() {
       @Override
       public void run() {
         long start = System.currentTimeMillis();

--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKManager.java
@@ -143,6 +143,7 @@ import com.taobao.weex.bridge.WXBridgeManager;
 import com.taobao.weex.bridge.WXModuleManager;
 import com.taobao.weex.common.WXRefreshData;
 import com.taobao.weex.common.WXRuntimeException;
+import com.taobao.weex.common.WXThread;
 import com.taobao.weex.dom.WXDomManager;
 import com.taobao.weex.ui.WXRenderManager;
 import com.taobao.weex.utils.WXLogUtils;
@@ -218,7 +219,7 @@ public class WXSDKManager {
   }
 
   public void postOnUiThread(Runnable runnable, long delayMillis) {
-    mWXRenderManager.postOnUiThread(runnable, delayMillis);
+    mWXRenderManager.postOnUiThread(WXThread.secure(runnable), delayMillis);
   }
 
   public void destroy() {

--- a/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
@@ -283,10 +283,6 @@ public class WXBridgeManager implements Callback {
   private static final String UNDEFINED = "-1";
   private static final int INIT_FRAMEWORK_OK = 1;
 
-  public static final int DESTROY_INSTANCE = -1;
-  public static final int INSTANCE_RENDERING = 1;
-  public static final int INSTANCE_RENDERING_ERROR = 0;
-
   private static long LOW_MEM_VALUE = 80;
 
   static WXBridgeManager mBridgeManager;
@@ -369,16 +365,6 @@ public class WXBridgeManager implements Callback {
   }
 
   /**
-   * Get Handler for JS Thread.
-   * careful with this method, inappropriate using of JS handler may cause
-   * significant performance penalty.
-   * @return Handler the handler in JS thread.
-   */
-  public Handler getJSHandler() {
-    return mJSHandler;
-  }
-
-  /**
    * Model switch. For now, debug model and release model are supported
    */
   public void restart() {
@@ -403,12 +389,20 @@ public class WXBridgeManager implements Callback {
     }, instanceId);
   }
 
-  private void post(Runnable r, Object token) {
+  public void post(Runnable r){
+    if (mJSHandler == null){
+      return;
+    }
+
+    mJSHandler.post(WXThread.secure(r));
+  }
+
+  public void post(Runnable r, Object token) {
     if (mJSHandler == null) {
       return;
     }
 
-    Message m = Message.obtain(mJSHandler, r);
+    Message m = Message.obtain(mJSHandler, WXThread.secure(r));
     m.obj = token;
     m.sendToTarget();
   }
@@ -454,7 +448,7 @@ public class WXBridgeManager implements Callback {
       WXErrorCode errorCode=WXErrorCode.WX_ERR_INVOKE_NATIVE;
       errorCode.appendErrMsg("[WXBridgeManager] callNative: call Native tasks is null");
       commitJSBridgeAlarmMonitor(instanceId, errorCode);
-      return INSTANCE_RENDERING_ERROR;
+      return IWXBridge.INSTANCE_RENDERING_ERROR;
     }
 
     if (WXEnvironment.isApkDebugable()) {
@@ -466,7 +460,7 @@ public class WXBridgeManager implements Callback {
 
     if(mDestroyedInstanceId!=null &&mDestroyedInstanceId.contains(instanceId)){
       commitJSBridgeAlarmMonitor(instanceId, WXErrorCode.WX_ERR_JS_EXECUTE);
-      return DESTROY_INSTANCE;
+      return IWXBridge.DESTROY_INSTANCE;
     }
 
 
@@ -503,11 +497,11 @@ public class WXBridgeManager implements Callback {
 
     if (UNDEFINED.equals(callback)) {
       commitJSBridgeAlarmMonitor(instanceId, WXErrorCode.WX_ERR_JS_EXECUTE);
-      return INSTANCE_RENDERING_ERROR;
+      return IWXBridge.INSTANCE_RENDERING_ERROR;
     }
     // get next tick
     getNextTick(instanceId, callback);
-    return INSTANCE_RENDERING;
+    return IWXBridge.INSTANCE_RENDERING;
   }
 
   private void getNextTick(final String instanceId, final String callback) {
@@ -517,7 +511,7 @@ public class WXBridgeManager implements Callback {
 
 
   private void addJSTask(final String method, final String instanceId, final Object... args) {
-    mJSHandler.post(new Runnable() {
+    post(new Runnable() {
       @Override
       public void run() {
         if (args == null || args.length == 0) {
@@ -632,7 +626,7 @@ public class WXBridgeManager implements Callback {
     if (TextUtils.isEmpty(instanceId) || jsonData == null) {
       return;
     }
-    mJSHandler.postDelayed((new Runnable() {
+    mJSHandler.postDelayed(WXThread.secure(new Runnable() {
       @Override
       public void run() {
         invokeRefreshInstance(instanceId, jsonData);

--- a/android/sdk/src/main/java/com/taobao/weex/bridge/WXModuleManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/WXModuleManager.java
@@ -256,7 +256,7 @@ public class WXModuleManager {
       return false;
     }
 
-    WXBridgeManager.getInstance().getJSHandler().post(new Runnable() {
+    WXBridgeManager.getInstance().post(new Runnable() {
       @Override
       public void run() {
         if (sModuleFactoryMap.containsKey(moduleName)) {

--- a/android/sdk/src/main/java/com/taobao/weex/common/IWXBridge.java
+++ b/android/sdk/src/main/java/com/taobao/weex/common/IWXBridge.java
@@ -212,6 +212,10 @@ import com.taobao.weex.bridge.WXParams;
  */
 public interface IWXBridge extends IWXObject {
 
+  int DESTROY_INSTANCE = -1;
+  int INSTANCE_RENDERING = 1;
+  int INSTANCE_RENDERING_ERROR = 0;
+
   /**
    * init Weex
    *

--- a/android/sdk/src/main/java/com/taobao/weex/common/WXThread.java
+++ b/android/sdk/src/main/java/com/taobao/weex/common/WXThread.java
@@ -207,6 +207,8 @@ package com.taobao.weex.common;
 import android.os.Handler;
 import android.os.Handler.Callback;
 import android.os.HandlerThread;
+import com.taobao.weex.WXEnvironment;
+import com.taobao.weex.utils.WXLogUtils;
 
 /**
  * Thread used in weex
@@ -214,6 +216,42 @@ import android.os.HandlerThread;
 public class WXThread extends HandlerThread {
 
   private Handler mHandler;
+
+  static class SafeRunnable implements Runnable {
+
+    static final String TAG = "SafeRunnable";
+
+    final Runnable mTask;
+    SafeRunnable(Runnable task){
+      mTask = task;
+    }
+
+    @Override
+    public void run() {
+      try {
+        if(mTask != null)
+          mTask.run();
+      }catch (Throwable e){
+        //catch everything may throw from exection.
+        if(WXEnvironment.isApkDebugable()){
+          e.printStackTrace();
+          WXLogUtils.e(TAG,"SafeRunnable run throw expection:"+e.getMessage());
+        }
+      }
+    }
+  }
+
+  /**
+   * Secure Runnable to prevent throw during execution.
+   * @param runnable
+   * @return
+   */
+  public static Runnable secure(Runnable runnable){
+    if(runnable == null || runnable instanceof SafeRunnable){
+      return runnable;
+    }
+    return new SafeRunnable(runnable);
+  }
 
   /**
    * @param name name of thread

--- a/android/sdk/src/main/java/com/taobao/weex/dom/WXDomManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/dom/WXDomManager.java
@@ -288,7 +288,7 @@ public final class WXDomManager {
         || mDomThread.getLooper() == null) {
       return;
     }
-    mDomHandler.post(task);
+    mDomHandler.post(WXThread.secure(task));
   }
 
   /**

--- a/android/sdk/src/main/java/com/taobao/weex/ui/WXComponentRegistry.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/WXComponentRegistry.java
@@ -234,7 +234,7 @@ public class WXComponentRegistry {
     componentInfo.put("type",type);
     final Map<String, String> registerInfo = componentInfo;
     //execute task in js thread to make sure register order is same as the order invoke register method.
-    WXBridgeManager.getInstance().getJSHandler()
+    WXBridgeManager.getInstance()
     .post(new Runnable() {
       @Override
       public void run() {
@@ -274,7 +274,7 @@ public class WXComponentRegistry {
   }
 
   public static void reload(){
-    WXBridgeManager.getInstance().getJSHandler().post(new Runnable() {
+    WXBridgeManager.getInstance().post(new Runnable() {
       @Override
       public void run() {
         try {

--- a/android/sdk/src/main/java/com/taobao/weex/ui/WXRenderManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/WXRenderManager.java
@@ -210,6 +210,7 @@ import android.text.TextUtils;
 
 import com.taobao.weex.WXSDKInstance;
 import com.taobao.weex.common.WXRuntimeException;
+import com.taobao.weex.common.WXThread;
 import com.taobao.weex.dom.WXDomObject;
 import com.taobao.weex.dom.flex.Spacing;
 import com.taobao.weex.ui.animation.WXAnimationBean;
@@ -256,7 +257,7 @@ public class WXRenderManager {
   }
 
   public void postOnUiThread(Runnable runnable, long delayMillis) {
-    mWXRenderHandler.postDelayed(runnable, delayMillis);
+    mWXRenderHandler.postDelayed(WXThread.secure(runnable), delayMillis);
   }
 
   /**
@@ -275,7 +276,7 @@ public class WXRenderManager {
 
   //TODO Use runnable temporarily
   public void runOnThread(final String instanceId, final IWXRenderTask task) {
-    mWXRenderHandler.post(new Runnable() {
+    mWXRenderHandler.post(WXThread.secure(new Runnable() {
 
       @Override
       public void run() {
@@ -284,7 +285,7 @@ public class WXRenderManager {
         }
         task.execute();
       }
-    });
+    }));
   }
 
   public void createInstance(WXSDKInstance instance) {

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
@@ -218,6 +218,7 @@ import com.taobao.weex.WXSDKInstance;
 import com.taobao.weex.WXSDKManager;
 import com.taobao.weex.common.OnWXScrollListener;
 import com.taobao.weex.common.WXDomPropConstant;
+import com.taobao.weex.common.WXThread;
 import com.taobao.weex.dom.WXDomObject;
 import com.taobao.weex.ui.ComponentCreator;
 import com.taobao.weex.ui.component.helper.WXStickyHelper;
@@ -362,24 +363,24 @@ public class WXScroller extends WXVContainer<ViewGroup> implements WXScrollViewL
     if (child instanceof WXRefresh) {
       ((BaseBounceView)mHost).setOnRefreshListener((WXRefresh)child);
       final WXComponent temp = child;
-      Runnable runnable=new Runnable(){
+      Runnable runnable = WXThread.secure(new Runnable(){
         @Override
         public void run() {
           ((BaseBounceView)mHost).setHeaderView(temp.getHostView());
         }
-      };
+      });
       handler.postDelayed(runnable,100);
     }
 
     if (child instanceof WXLoading) {
       ((BaseBounceView)mHost).setOnLoadingListener((WXLoading)child);
       final WXComponent temp = child;
-      Runnable runnable=new Runnable(){
+      Runnable runnable=WXThread.secure(new Runnable(){
         @Override
         public void run() {
           ((BaseBounceView)mHost).setFooterView(temp.getHostView());
         }
-      };
+      });
       handler.postDelayed(runnable,100);
     }
   }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXEditText.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXEditText.java
@@ -209,6 +209,7 @@ import android.os.Build;
 import android.view.MotionEvent;
 import android.widget.EditText;
 
+import com.taobao.weex.common.WXThread;
 import com.taobao.weex.ui.view.gesture.WXGesture;
 import com.taobao.weex.ui.view.gesture.WXGestureObservable;
 
@@ -240,5 +241,10 @@ public class WXEditText extends EditText implements WXGestureObservable {
       result |= wxGesture.onTouch(this, event);
     }
     return result;
+  }
+
+  @Override
+  public boolean postDelayed(Runnable action, long delayMillis) {
+    return super.postDelayed(WXThread.secure(action), delayMillis);
   }
 }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXHorizontalScrollView.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXHorizontalScrollView.java
@@ -210,6 +210,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.HorizontalScrollView;
 
+import com.taobao.weex.common.WXThread;
 import com.taobao.weex.ui.view.gesture.WXGesture;
 import com.taobao.weex.ui.view.gesture.WXGestureObservable;
 
@@ -217,6 +218,11 @@ public class WXHorizontalScrollView extends HorizontalScrollView implements IWXS
 
   private WXGesture wxGesture;
   private ScrollViewListener mScrollViewListener;
+
+  @Override
+  public boolean postDelayed(Runnable action, long delayMillis) {
+    return super.postDelayed(WXThread.secure(action), delayMillis);
+  }
 
   public WXHorizontalScrollView(Context context) {
     super(context);

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/listview/WXRecyclerView.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/listview/WXRecyclerView.java
@@ -210,6 +210,7 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.OrientationHelper;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.StaggeredGridLayoutManager;
+import com.taobao.weex.common.WXThread;
 
 public class WXRecyclerView extends RecyclerView {
 
@@ -219,6 +220,11 @@ public class WXRecyclerView extends RecyclerView {
 
   public WXRecyclerView(Context context) {
     super(context);
+  }
+
+  @Override
+  public boolean postDelayed(Runnable action, long delayMillis) {
+    return super.postDelayed(WXThread.secure(action), delayMillis);
   }
 
   /**

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/refresh/core/WXRefreshView.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/refresh/core/WXRefreshView.java
@@ -212,6 +212,7 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
+import com.taobao.weex.common.WXThread;
 import com.taobao.weex.ui.view.refresh.circlebar.CircleProgressBar;
 
 public class WXRefreshView extends FrameLayout {
@@ -242,6 +243,11 @@ public class WXRefreshView extends FrameLayout {
     linearLayout.setOrientation(LinearLayout.VERTICAL);
     linearLayout.setGravity(Gravity.CENTER);
     addView(linearLayout,lp);
+  }
+
+  @Override
+  public boolean post(Runnable action) {
+    return super.post(WXThread.secure(action));
   }
 
   /**

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/refresh/wrapper/BounceRecyclerView.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/refresh/wrapper/BounceRecyclerView.java
@@ -210,6 +210,7 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.taobao.weex.common.WXThread;
 import com.taobao.weex.ui.component.WXComponent;
 import com.taobao.weex.ui.component.list.WXCell;
 import com.taobao.weex.ui.view.listview.WXRecyclerView;
@@ -222,6 +223,11 @@ public class BounceRecyclerView extends BaseBounceView<WXRecyclerView> {
   private RecyclerViewBaseAdapter adapter = null;
   private Stack<View> headerViewStack = new Stack<>();
   private Stack<WXCell> headComponentStack = new Stack<>();
+
+  @Override
+  public boolean postDelayed(Runnable action, long delayMillis) {
+    return super.postDelayed(WXThread.secure(action), delayMillis);
+  }
 
   public BounceRecyclerView(Context context, int orientation) {
     super(context, orientation);

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/refresh/wrapper/BounceScrollerView.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/refresh/wrapper/BounceScrollerView.java
@@ -206,12 +206,18 @@ package com.taobao.weex.ui.view.refresh.wrapper;
 
 import android.content.Context;
 
+import com.taobao.weex.common.WXThread;
 import com.taobao.weex.ui.component.WXScroller;
 import com.taobao.weex.ui.view.WXScrollView;
 
 public class BounceScrollerView extends BaseBounceView<WXScrollView> {
 
-    public BounceScrollerView(Context context, int orientation,WXScroller waScroller) {
+    @Override
+    public boolean postDelayed(Runnable action, long delayMillis) {
+        return super.postDelayed(WXThread.secure(action), delayMillis);
+    }
+
+    public BounceScrollerView(Context context, int orientation, WXScroller waScroller) {
         super(context,orientation);
         if (getInnerView() != null)
             getInnerView().setWAScroller(waScroller);

--- a/android/sdk/src/test/java/com/taobao/weex/bridge/WXBridgeManagerTest.java
+++ b/android/sdk/src/test/java/com/taobao/weex/bridge/WXBridgeManagerTest.java
@@ -233,8 +233,9 @@ public class WXBridgeManagerTest extends TestCase {
 
     @Test
     public void testGetJSHander() throws Exception {
-        Handler handler=WXBridgeManager.getInstance().getJSHandler();
-        assertNotNull(handler);
+//        Handler handler=WXBridgeManager.getInstance().getJSHandler();
+//        assertNotNull(handler);
+
     }
 
     public void testGetInstance() throws Exception {

--- a/android/weex_debug/src/main/java/com/taobao/weex/bridge/WXWebsocketBridge.java
+++ b/android/weex_debug/src/main/java/com/taobao/weex/bridge/WXWebsocketBridge.java
@@ -268,9 +268,9 @@ public class WXWebsocketBridge implements IWXBridge,WXWebSocketManager.JSDebugge
     @Override
     public int callNative(String instanceId, String tasks, String callback) {
         if (!mInit || mJsManager == null)
-            return WXBridgeManager.INSTANCE_RENDERING_ERROR ;
+            return IWXBridge.INSTANCE_RENDERING_ERROR ;
         mJsManager.callNative(instanceId, tasks, callback);
-        return WXBridgeManager.INSTANCE_RENDERING;
+        return IWXBridge.INSTANCE_RENDERING;
     }
 
     @Override


### PR DESCRIPTION
对各线程的执行添加catch保护,避免crash:
1. 对`callNative`执行添加保护
2. 对使用`Runnable`分发任务的方式,统一进行保护处理
