### PR TITLE
* [android] add fixed size property

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
@@ -184,6 +184,11 @@ import java.util.Set;
  */
 public abstract class  WXComponent<T extends View> implements IWXObject, IWXActivityStateListener {
 
+  public static final String PROP_FIXED_SIZE = "fixedSize";
+  public static final String PROP_FS_MATCH_PARENT = "m";
+  public static final String PROP_FS_WRAP_CONTENT = "w";
+
+  private int mFixedProp = 0;
   public static int mComponentNum = 0;
   /** package **/ T mHost;
 
@@ -546,8 +551,14 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
    */
   protected MeasureOutput measure(int width, int height) {
     MeasureOutput measureOutput = new MeasureOutput();
-    measureOutput.width = width;
-    measureOutput.height = height;
+
+    if(mFixedProp != 0){
+      measureOutput.width = mFixedProp;
+      measureOutput.height = mFixedProp;
+    }else {
+      measureOutput.width = width;
+      measureOutput.height = height;
+    }
     return measureOutput;
   }
 
@@ -647,6 +658,10 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
         if (visibility != null)
           setVisibility(visibility);
         return true;
+      case PROP_FIXED_SIZE:
+        String fixedSize = WXUtils.getString(param, PROP_FS_MATCH_PARENT);
+        setFixedSize(fixedSize);
+        return true;
       case Constants.Name.WIDTH:
       case Constants.Name.MIN_WIDTH:
       case Constants.Name.MAX_WIDTH:
@@ -676,6 +691,29 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
         return true;
       default:
         return false;
+    }
+  }
+
+  /**
+   * Avoid large size view fail in GPU-Animation.
+   * @param fixedSize
+   */
+  private void setFixedSize(String fixedSize) {
+    if(PROP_FS_MATCH_PARENT.equals(fixedSize)){
+      mFixedProp = ViewGroup.LayoutParams.MATCH_PARENT;
+    }else if(PROP_FS_WRAP_CONTENT.equals(fixedSize)){
+      mFixedProp = ViewGroup.LayoutParams.WRAP_CONTENT;
+    }else{
+      mFixedProp = 0;
+      return;
+    }
+    if(mHost != null){
+      ViewGroup.LayoutParams layoutParams = mHost.getLayoutParams();
+      if(layoutParams != null){
+        layoutParams.height = mFixedProp;
+        layoutParams.width = mFixedProp;
+        mHost.setLayoutParams(layoutParams);
+      }
     }
   }
 


### PR DESCRIPTION
根据layout计算的结果list以及list以外的所有component的高度会变得非常大,view的尺寸也会变得非常大,在某些场景下(比如使用硬件加速,进行动画)时就会报错,所以android这边需要对这种场景进行一定的hack.

大家看看这个需求是像现在这样添加特殊属性,在需要的时候添加呢,还是作为默认的优化来实现.

```
<template>
  <div fixed-size="m">
    <div fixed-size="m">
      <list fixed-size="m">
        <cell repeat="article in articles">
          <div class="text">
            <text onclick="click">{{article}}</text>
          </div>
        </cell>
      </list>
    </div>
  </div>
</template>

<style>
.text {
  height: 600;
}
</style>


<script>
module.exports = {
  data: {
    articles: ['test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7', 'test8', 'test9', 'test10']
  },
  method:{
  click:function(){}
  }
}
</script>
```
