### PR TITLE
恢复slider循环滚动限制

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXBaseCircleIndicator.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXBaseCircleIndicator.java
@@ -323,7 +323,7 @@ public class WXBaseCircleIndicator extends FrameLayout implements OnPageChangeLi
 
   @Override
   public void onPageSelected(int position) {
-    realCurrentItem = position % getCount();
+    realCurrentItem = mCircleViewPager.getRealCurrentItem();
     invalidate();
     if (mListener != null) {
       mListener.onPageSelected(position);

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXCirclePageAdapter.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXCirclePageAdapter.java
@@ -322,7 +322,7 @@ public class WXCirclePageAdapter extends PagerAdapter {
 
   private void ensureShadow() {
     shadow.clear();
-    if (needLoop) {
+    if (needLoop && views.size() > 2) {
       shadow.add(0, views.get(views.size() - 1));
       for (View view : views) {
         shadow.add(view);
@@ -346,7 +346,7 @@ public class WXCirclePageAdapter extends PagerAdapter {
   }
 
   public int getFirst() {
-    if (needLoop) {
+    if (needLoop && views.size() > 2) {
       return getRealCount() + 1;
     } else {
       return 0;

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXCircleViewPager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXCircleViewPager.java
@@ -413,7 +413,7 @@ public class WXCircleViewPager extends ViewPager implements WXGestureObservable 
     this.wxGesture = wxGesture;
   }
 
-  private int getRealCurrentItem() {
+  public int getRealCurrentItem() {
     int i = super.getCurrentItem();
     return ((WXCirclePageAdapter) getAdapter()).getRealPosition(i);
   }


### PR DESCRIPTION
item数量小于3时禁止循环滚动
修复Indicator index偏移的问题
test case:
http://dotwe.org/20893651592090cdf26a495e9e5352f1 