### PR TITLE
Sliderneighbor bugfix

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSliderNeighbor.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSliderNeighbor.java
@@ -208,7 +208,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewPager;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -300,7 +299,7 @@ public class WXSliderNeighbor extends WXSlider {
 
     /**
      * we do it in a hack way.
-     * travel the dom tree, to get how many children does this silder-neighbor have.
+     * travel the dom tree, to get how many children does this slider-neighbor have.
      *
      * @return
      */
@@ -317,7 +316,14 @@ public class WXSliderNeighbor extends WXSlider {
             ConcurrentHashMap<String, WXDomObject> mRegistryMap = (ConcurrentHashMap<String, WXDomObject>) mRegistryField.get(domStatement);
             for(WXDomObject domObject : mRegistryMap.values()) {
                 if(domObject.getType().equalsIgnoreCase(WXBasicComponentType.SLIDER_NEIGHBOR)) {
-                    return domObject.getChildCount();
+                    int sum = 0;
+                    for (int i = 0,count = domObject.getChildCount(); i < count; i++) {
+                        if(domObject.getChild(i) instanceof WXIndicator.IndicatorDomNode) {
+                            continue;
+                        }
+                        sum++;
+                    }
+                    return sum;
                 }
             }
         } catch (Exception e) {
@@ -534,16 +540,16 @@ public class WXSliderNeighbor extends WXSlider {
     private class ZoomTransformer implements ViewPager.PageTransformer {
         @Override
         public void transformPage(View page, float position) {
-            int pagePostition = mAdapter.getPagePostion(page);
-            int currentPostion = mViewPager.getCurrentItem();
+            int pagePosition = mAdapter.getPagePostion(page);
+            int curPosition = mViewPager.getCurrentItem();
             boolean ignore = false;
-            if(currentPostion != 0 && currentPostion != mAdapter.getRealCount() - 1 && Math.abs(pagePostition - currentPostion) > 1)  {
+            if(curPosition != 0 && curPosition != mAdapter.getRealCount() - 1 && Math.abs(pagePosition - curPosition) > 1)  {
                 ignore = true;
             }
-            if(currentPostion == 0 && pagePostition < mAdapter.getRealCount() - 1 && pagePostition > 1) {
+            if(curPosition == 0 && pagePosition < mAdapter.getRealCount() - 1 && pagePosition > 1) {
                 ignore = true;
             }
-            if(currentPostion == mAdapter.getRealCount() - 1 && pagePostition < mAdapter.getRealCount() - 2 && pagePostition > 0) {
+            if(curPosition == mAdapter.getRealCount() - 1 && pagePosition < mAdapter.getRealCount() - 2 && pagePosition > 0) {
                 ignore = true;
             }
             // just transfer the neighbor(left & right) page.

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSliderNeighbor.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSliderNeighbor.java
@@ -386,7 +386,7 @@ public class WXSliderNeighbor extends WXSlider {
             final View currentPage = pageViews.get(curPos);
             updateScaleAndAlpha(((ViewGroup)currentPage).getChildAt(0),1.0F,WX_DEFAULT_MAIN_NEIGHBOR_SCALE);
 
-            if(pageViews.size() < 3) {
+            if(pageViews.size() < 2) {
                 return;
             }
             //make sure View's width & height are measured.
@@ -417,15 +417,28 @@ public class WXSliderNeighbor extends WXSlider {
         float translation = calculateTranslation(currentPage);
         int left = (curPos == 0) ? pageViews.size()-1 : curPos-1;
         View leftPage = pageViews.get(left);
-        updateScaleAndAlpha(((ViewGroup)leftPage).getChildAt(0), alpha, scale);
-        leftPage.setTranslationX(translation);
-        ((ViewGroup)leftPage).getChildAt(0).setTranslationX(translation);
-
         int right = (curPos == pageViews.size()-1) ? 0 : curPos+1;
         View rightPage = pageViews.get(right);
-        updateScaleAndAlpha(((ViewGroup)rightPage).getChildAt(0), alpha, scale);
-        rightPage.setTranslationX(-translation);
-        ((ViewGroup)rightPage).getChildAt(0).setTranslationX(-translation);
+
+        if(pageViews.size() == 2) {
+            if(curPos == 0) {
+                moveRight(rightPage, translation, alpha, scale);
+            }else if(curPos == 1) {
+                moveLeft(leftPage, translation, alpha, scale);
+            }
+        } else {
+            moveLeft(leftPage, translation, alpha, scale);
+            moveRight(rightPage, translation, alpha, scale);
+        }
+    }
+
+    private void moveLeft(View page, float translation, float alpha, float scale) {
+        updateScaleAndAlpha(((ViewGroup)page).getChildAt(0), alpha, scale);
+        page.setTranslationX(translation);
+        ((ViewGroup)page).getChildAt(0).setTranslationX(translation);
+    }
+    private void moveRight(View page, float translation, float alpha, float scale) {
+        moveLeft(page, -translation, alpha, scale);
     }
 
     @WXComponentProp(name = NEIGHBOR_SCALE)
@@ -566,6 +579,9 @@ public class WXSliderNeighbor extends WXSlider {
                     realView.setTranslationX(0);
                     updateAdapterScaleAndAlpha(mNeighborAlpha, mNeighborScale);
                 }else{
+                    if(mAdapter.getRealCount() == 2 && Math.abs(position) == 1) {
+                        return;
+                    }
                     translation = (-position*translation);
                     realView.setTranslationX(translation);
                     page.setTranslationX(translation);

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSliderNeighbor.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSliderNeighbor.java
@@ -396,14 +396,14 @@ public class WXSliderNeighbor extends WXSlider {
                 return;
             }
             //make sure View's width & height are measured.
-            currentPage.post(new Runnable() {
+            currentPage.post(WXThread.secure(new Runnable() {
                 @Override
                 public void run() {
                     //change left and right page's translation
                     updateNeighbor(currentPage, alpha, scale);
 
                 }
-            });
+            }));
 
             // make sure only display view current, left, right.
             int left = (curPos == 0) ? pageViews.size()-1 : curPos-1;
@@ -540,7 +540,7 @@ public class WXSliderNeighbor extends WXSlider {
     private class ZoomTransformer implements ViewPager.PageTransformer {
         @Override
         public void transformPage(View page, float position) {
-            int pagePosition = mAdapter.getPagePostion(page);
+            int pagePosition = mAdapter.getPagePosition(page);
             int curPosition = mViewPager.getCurrentItem();
             boolean ignore = false;
             if(curPosition != 0 && curPosition != mAdapter.getRealCount() - 1 && Math.abs(pagePosition - curPosition) > 1)  {

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXCirclePageAdapter.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXCirclePageAdapter.java
@@ -312,7 +312,7 @@ public class WXCirclePageAdapter extends PagerAdapter {
     return POSITION_NONE;
   }
 
-  public int getPagePostion(View page) {
+  public int getPagePosition(View page) {
     return views.indexOf(page);
   }
 

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXCirclePageAdapter.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXCirclePageAdapter.java
@@ -275,7 +275,7 @@ public class WXCirclePageAdapter extends PagerAdapter {
   }
 
   @Override
-  public Object instantiateItem(ViewGroup container, int position) {
+  public synchronized Object instantiateItem(ViewGroup container, int position) {
     View pageView = null;
     try {
       pageView = shadow.get(position);
@@ -336,7 +336,6 @@ public class WXCirclePageAdapter extends PagerAdapter {
       temp.addAll(views);
     }
     shadow.clear();
-    notifyDataSetChanged();
     shadow.addAll(temp);
     notifyDataSetChanged();
   }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXCirclePageAdapter.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXCirclePageAdapter.java
@@ -275,7 +275,7 @@ public class WXCirclePageAdapter extends PagerAdapter {
   }
 
   @Override
-  public synchronized Object instantiateItem(ViewGroup container, int position) {
+  public Object instantiateItem(ViewGroup container, int position) {
     View pageView = null;
     try {
       pageView = shadow.get(position);
@@ -312,6 +312,10 @@ public class WXCirclePageAdapter extends PagerAdapter {
     return POSITION_NONE;
   }
 
+  public int getPagePostion(View page) {
+    return views.indexOf(page);
+  }
+
   public int getItemIndex(Object object) {
     if (object instanceof View) {
       return views.indexOf(object);
@@ -336,6 +340,7 @@ public class WXCirclePageAdapter extends PagerAdapter {
       temp.addAll(views);
     }
     shadow.clear();
+    notifyDataSetChanged();
     shadow.addAll(temp);
     notifyDataSetChanged();
   }


### PR DESCRIPTION
修复slider-neighbor出现的各种诡异问题，比如：
- 加载异步数据时首屏渲染错位；
- 仅两个item时左/右无法透出item；
- 与indicator混用时出现渲染错位；
- ...