### PR TITLE
* [android] ClipPath doesn't work on Android.

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/utils/WXViewUtils.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/WXViewUtils.java
@@ -538,8 +538,12 @@ public class WXViewUtils {
     /* According to https://developer.android.com/guide/topics/graphics/hardware-accel.html#unsupported
       API 18 or higher supports clipPath to canvas based on hardware acceleration.
      */
-    if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2 ||
-         !canvas.isHardwareAccelerated()) &&
+    /**
+     * According to https://code.google.com/p/android/issues/detail?id=225556&sort=-id&colspec=ID
+     * clipPath doesn't work with rotation nor scale when API level is 24 or higher.
+     */
+    if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2 || !canvas.isHardwareAccelerated()) &&
+        Build.VERSION.SDK_INT <= Build.VERSION_CODES.M &&
         ((drawable = targetView.getBackground()) instanceof BorderDrawable)) {
       BorderDrawable borderDrawable = (BorderDrawable) drawable;
       if(borderDrawable.isRounded()) {


### PR DESCRIPTION
ClipPath doesn't work on when following conditions met
* rotation or scale is used
* API level is 24

As border-radius uses clipPath, this will cause views with border-radius using rotation or scale on API level 24 doesn't.So far, this is a [bug of Android N](https://code.google.com/p/android/issues/detail?id=225556&sort=-id&colspec=ID).

Whether this bug will be fixed on API 25 or higher is unknown so far, so ClipPath will be disabled when API level is 24 or higher.